### PR TITLE
synchronize_users: remove not useful slash

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -43,6 +43,10 @@ function synchronize_users() {
     ynh_print_info --message="Synchronizing forgejo users"
     # Fetch the token independently such that it's redacted by Yunohost logging mechanism
     forgejo_api_token=$(ynh_app_setting_get --app=$app --key=forgejo_api_token)
+
+    # Remove trailing slash from path
+    local no_trailing_slash_path=${path%/}
+
     # User synchronization must be launched using API : no cli exists for this purpose (https://codeberg.org/forgejo/forgejo/issues/953)
-    curl --url https://${domain}${path}/api/v1/admin/cron/sync_external_users -X POST -H "Authorization: token $forgejo_api_token" -kfsS
+    curl --url https://${domain}${no_trailing_slash_path}/api/v1/admin/cron/sync_external_users -X POST -H "Authorization: token $forgejo_api_token" -kfsS
 }


### PR DESCRIPTION
`$path` can be `/` so we can get `https://domain2.tld//api/`