### PR TITLE
[autopatch] TEST BEFORE MERGE ynh_setup_source --full_replace=1

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ Brought to you by an inclusive community under the umbrella of Codeberg e.V., a 
 - Authentication via SMTP, LDAP.
 - Customize HTML templates, static files and many others.
 
-
 **Shipped version:** 1.21.6-0~ynh1
 
 ## Screenshots
@@ -42,12 +41,12 @@ Brought to you by an inclusive community under the umbrella of Codeberg e.V., a 
 
 ## Documentation and resources
 
-* Official app website: <https://forgejo.org>
-* Official user documentation: <https://forgejo.org/docs/latest/user/>
-* Official admin documentation: <https://forgejo.org/docs/latest/admin/>
-* Upstream app code repository: <https://codeberg.org/forgejo/forgejo>
-* YunoHost Store: <https://apps.yunohost.org/app/forgejo>
-* Report a bug: <https://github.com/YunoHost-Apps/forgejo_ynh/issues>
+- Official app website: <https://forgejo.org>
+- Official user documentation: <https://forgejo.org/docs/latest/user/>
+- Official admin documentation: <https://forgejo.org/docs/latest/admin/>
+- Upstream app code repository: <https://codeberg.org/forgejo/forgejo>
+- YunoHost Store: <https://apps.yunohost.org/app/forgejo>
+- Report a bug: <https://github.com/YunoHost-Apps/forgejo_ynh/issues>
 
 ## Developer info
 
@@ -55,7 +54,7 @@ Please send your pull request to the [testing branch](https://github.com/YunoHos
 
 To try the testing branch, please proceed like that.
 
-``` bash
+```bash
 sudo yunohost app install https://github.com/YunoHost-Apps/forgejo_ynh/tree/testing --debug
 or
 sudo yunohost app upgrade forgejo -u https://github.com/YunoHost-Apps/forgejo_ynh/tree/testing --debug

--- a/README_fr.md
+++ b/README_fr.md
@@ -33,7 +33,6 @@ Présenté par une communauté inclusive sous l'égide de Codeberg e.V., une org
 - Authentification via SMTP, LDAP.
 - Modèle personnalisé HTML, de fichiers statiques et de nombreux autres.
 
-
 **Version incluse :** 1.21.6-0~ynh1
 
 ## Captures d’écran
@@ -42,12 +41,12 @@ Présenté par une communauté inclusive sous l'égide de Codeberg e.V., une org
 
 ## Documentations et ressources
 
-* Site officiel de l’app : <https://forgejo.org>
-* Documentation officielle utilisateur : <https://forgejo.org/docs/latest/user/>
-* Documentation officielle de l’admin : <https://forgejo.org/docs/latest/admin/>
-* Dépôt de code officiel de l’app : <https://codeberg.org/forgejo/forgejo>
-* YunoHost Store: <https://apps.yunohost.org/app/forgejo>
-* Signaler un bug : <https://github.com/YunoHost-Apps/forgejo_ynh/issues>
+- Site officiel de l’app : <https://forgejo.org>
+- Documentation officielle utilisateur : <https://forgejo.org/docs/latest/user/>
+- Documentation officielle de l’admin : <https://forgejo.org/docs/latest/admin/>
+- Dépôt de code officiel de l’app : <https://codeberg.org/forgejo/forgejo>
+- YunoHost Store : <https://apps.yunohost.org/app/forgejo>
+- Signaler un bug : <https://github.com/YunoHost-Apps/forgejo_ynh/issues>
 
 ## Informations pour les développeurs
 
@@ -55,7 +54,7 @@ Merci de faire vos pull request sur la [branche testing](https://github.com/Yuno
 
 Pour essayer la branche testing, procédez comme suit.
 
-``` bash
+```bash
 sudo yunohost app install https://github.com/YunoHost-Apps/forgejo_ynh/tree/testing --debug
 ou
 sudo yunohost app upgrade forgejo -u https://github.com/YunoHost-Apps/forgejo_ynh/tree/testing --debug

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -85,7 +85,7 @@ fi
 #=================================================
 ynh_script_progression --message="Setting up source files..." --weight=3
 
-ynh_setup_source --dest_dir=$install_dir --full_replace=1
+ynh_setup_source --dest_dir=$install_dir --full_replace=1 --keep="custom"
 xz -f -d "$install_dir/forgejo.xz"
 
 chmod -R o-rwx "$install_dir"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -85,7 +85,7 @@ fi
 #=================================================
 ynh_script_progression --message="Setting up source files..." --weight=3
 
-ynh_setup_source --dest_dir=$install_dir
+ynh_setup_source --dest_dir=$install_dir --full_replace=1
 xz -f -d "$install_dir/forgejo.xz"
 
 chmod -R o-rwx "$install_dir"


### PR DESCRIPTION
This is an automatic PR

This is an ***automated*** patch to potentially fix a bug in the upgrade script.

`ynh_setup_source` doesn't overwrite the destination directory, but rather extracts the source in the existing directory.

This might lead to weird cases where legacy source files aren't deleted.

The command has an argument `--full_replace=1` that fixes this behaviour.

BE CAREFUL because this change might lead to data losses! You should check that all the patches calls to `ynh_setup_source`
_do exactly what you expect to do_ and don't **delete user data**.

If you want exclude some files from being overwritten/deleted, use the `--keep` argument, just like that:

```bash
ynh_setup_source --dest_dir="$install_dir" --full_replace=1 --keep="config/config.yaml"
```