### PR TITLE
Group sync

### DIFF
--- a/config_panel.toml
+++ b/config_panel.toml
@@ -120,3 +120,45 @@ help = "Config pertaining to repo mirroring."
     help.fr = "Exemples : '2h', '10m'"
     pattern.regexp = '(?!^[0-1]m$)(^[0-9]+(m$|h$|d$)$)'
     pattern.error = "Must begin with one or more digits and end with 'm', 'h' or 'd'. Must not be more than '1m'."
+
+
+[main.project]
+name = "Organisation and team"
+help = "Organisation and team member management. Note that after a creation of a team in forgejo you will need to trigger the sync group mapping to have the correct mapping between your forgejo team and your Yunohost groups."
+
+    [main.project.group_sync_enabled]
+    ask.en = "Enable group synchronisation from Yunohost to the organisation team members"
+    help.en = "When enabled, for all organisation teams which has the same name than a Yunohost group name, the members  will be synchronised."
+    type = "boolean"
+    yes = "true"
+    no = "false"
+
+    [main.project.group_sync_excluded_organisations]
+    ask.en = "Excluded organisations to sync group member"
+    help.en = "A list of organisation name to exclude from the group/team synchronisation."
+    type = "tags"
+    visible = "group_sync_enabled"
+
+    [main.project.group_sync_included_organisations]
+    ask.en = "Included organisations to sync group member"
+    help.en = "A list of organisation name to include from the group/team synchronisation. If set, this will exclude all not listed organisations."
+    type = "tags"
+    visible = "group_sync_enabled"
+
+    [main.project.group_sync_excluded_ynh_group]
+    ask.en = "Excluded Yunohost group to sync group member"
+    help.en = "A list of Yunohost group name to exclude from the group/team synchronisation."
+    type = "tags"
+    visible = "group_sync_enabled"
+
+    [main.project.group_sync_included_ynh_group]
+    ask.en = "Included Yunohost group to sync group member"
+    help.en = "A list of Yunohost group name to include from the group/team synchronisation. If set, this will exclude all not listed groups."
+    type = "tags"
+    visible = "group_sync_enabled"
+
+    [main.admin_users.sync_groups_mapping]
+    type = "button"
+    ask = "Force sync group mapping"
+    # disabled because of https://github.com/YunoHost/issues/issues/2488
+    # visible = "group_sync_enabled"

--- a/hooks/post_app_addaccess
+++ b/hooks/post_app_addaccess
@@ -16,9 +16,18 @@ app=${filename#*-}
 
 domain=$(ynh_app_setting_get --app=$app --key=domain)
 path=$(ynh_app_setting_get --app=$app --key=path)
+install_dir="$(ynh_app_setting_get --app=$app --key=install_dir)"
+db_name="$(ynh_app_setting_get --app=$app --key=db_name)"
+group_sync_enabled="$(ynh_app_setting_get --app=$app --key=group_sync_enabled)"
+group_sync_included_organisations="$(ynh_app_setting_get --app=$app --key=group_sync_included_organisations)"
+group_sync_excluded_organisations="$(ynh_app_setting_get --app=$app --key=group_sync_excluded_organisations)"
+group_sync_included_ynh_group="$(ynh_app_setting_get --app=$app --key=group_sync_included_ynh_group)"
+group_sync_excluded_ynh_group="$(ynh_app_setting_get --app=$app --key=group_sync_excluded_ynh_group)"
 
 # Load common variables and helpers
 source ${pwd}/../../apps/${app}/scripts/_common.sh
 
+pushd ${pwd}/../../apps/${app}/scripts/
 set_forgejo_login_source
+popd
 synchronize_users

--- a/hooks/post_app_addaccess
+++ b/hooks/post_app_addaccess
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+YNH_HELPERS_VERSION=2.1
+
 # IMPORT GENERIC HELPERS
 source /usr/share/yunohost/helpers
 

--- a/hooks/post_app_addaccess
+++ b/hooks/post_app_addaccess
@@ -18,4 +18,5 @@ path=$(ynh_app_setting_get --app=$app --key=path)
 # Load common variables and helpers
 source ${pwd}/../../apps/${app}/scripts/_common.sh
 
+set_forgejo_login_source
 synchronize_users

--- a/hooks/post_app_removeaccess
+++ b/hooks/post_app_removeaccess
@@ -17,4 +17,5 @@ path=$(ynh_app_setting_get --app=$app --key=path)
 # Load common variables and helpers
 source ${pwd}/../../apps/${app}/scripts/_common.sh
 
+set_forgejo_login_source
 synchronize_users

--- a/hooks/post_app_removeaccess
+++ b/hooks/post_app_removeaccess
@@ -15,9 +15,18 @@ app=${filename#*-}
 
 domain=$(ynh_app_setting_get --app=$app --key=domain)
 path=$(ynh_app_setting_get --app=$app --key=path)
+install_dir="$(ynh_app_setting_get --app=$app --key=install_dir)"
+db_name="$(ynh_app_setting_get --app=$app --key=db_name)"
+group_sync_enabled="$(ynh_app_setting_get --app=$app --key=group_sync_enabled)"
+group_sync_included_organisations="$(ynh_app_setting_get --app=$app --key=group_sync_included_organisations)"
+group_sync_excluded_organisations="$(ynh_app_setting_get --app=$app --key=group_sync_excluded_organisations)"
+group_sync_included_ynh_group="$(ynh_app_setting_get --app=$app --key=group_sync_included_ynh_group)"
+group_sync_excluded_ynh_group="$(ynh_app_setting_get --app=$app --key=group_sync_excluded_ynh_group)"
 
 # Load common variables and helpers
 source ${pwd}/../../apps/${app}/scripts/_common.sh
 
+pushd ${pwd}/../../apps/${app}/scripts/
 set_forgejo_login_source
+popd
 synchronize_users

--- a/hooks/post_app_removeaccess
+++ b/hooks/post_app_removeaccess
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+YNH_HELPERS_VERSION=2.1
+
 # IMPORT GENERIC HELPERS
 source /usr/share/yunohost/helpers
 

--- a/hooks/post_user_create
+++ b/hooks/post_user_create
@@ -17,4 +17,5 @@ path=$(ynh_app_setting_get --app=$app --key=path)
 # Load common variables and helpers
 source ${pwd}/../../apps/${app}/scripts/_common.sh
 
+set_forgejo_login_source
 synchronize_users

--- a/hooks/post_user_create
+++ b/hooks/post_user_create
@@ -15,9 +15,18 @@ app=${filename#*-}
 
 domain=$(ynh_app_setting_get --app=$app --key=domain)
 path=$(ynh_app_setting_get --app=$app --key=path)
+install_dir="$(ynh_app_setting_get --app=$app --key=install_dir)"
+db_name="$(ynh_app_setting_get --app=$app --key=db_name)"
+group_sync_enabled="$(ynh_app_setting_get --app=$app --key=group_sync_enabled)"
+group_sync_included_organisations="$(ynh_app_setting_get --app=$app --key=group_sync_included_organisations)"
+group_sync_excluded_organisations="$(ynh_app_setting_get --app=$app --key=group_sync_excluded_organisations)"
+group_sync_included_ynh_group="$(ynh_app_setting_get --app=$app --key=group_sync_included_ynh_group)"
+group_sync_excluded_ynh_group="$(ynh_app_setting_get --app=$app --key=group_sync_excluded_ynh_group)"
 
 # Load common variables and helpers
 source ${pwd}/../../apps/${app}/scripts/_common.sh
 
+pushd ${pwd}/../../apps/${app}/scripts/
 set_forgejo_login_source
+popd
 synchronize_users

--- a/hooks/post_user_create
+++ b/hooks/post_user_create
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+YNH_HELPERS_VERSION=2.1
+
 # IMPORT GENERIC HELPERS
 source /usr/share/yunohost/helpers
 

--- a/hooks/post_user_delete
+++ b/hooks/post_user_delete
@@ -17,4 +17,5 @@ path=$(ynh_app_setting_get --app=$app --key=path)
 # Load common variables and helpers
 source ${pwd}/../../apps/${app}/scripts/_common.sh
 
+set_forgejo_login_source
 synchronize_users

--- a/hooks/post_user_delete
+++ b/hooks/post_user_delete
@@ -15,9 +15,18 @@ app=${filename#*-}
 
 domain=$(ynh_app_setting_get --app=$app --key=domain)
 path=$(ynh_app_setting_get --app=$app --key=path)
+install_dir="$(ynh_app_setting_get --app=$app --key=install_dir)"
+db_name="$(ynh_app_setting_get --app=$app --key=db_name)"
+group_sync_enabled="$(ynh_app_setting_get --app=$app --key=group_sync_enabled)"
+group_sync_included_organisations="$(ynh_app_setting_get --app=$app --key=group_sync_included_organisations)"
+group_sync_excluded_organisations="$(ynh_app_setting_get --app=$app --key=group_sync_excluded_organisations)"
+group_sync_included_ynh_group="$(ynh_app_setting_get --app=$app --key=group_sync_included_ynh_group)"
+group_sync_excluded_ynh_group="$(ynh_app_setting_get --app=$app --key=group_sync_excluded_ynh_group)"
 
 # Load common variables and helpers
 source ${pwd}/../../apps/${app}/scripts/_common.sh
 
+pushd ${pwd}/../../apps/${app}/scripts/
 set_forgejo_login_source
+popd
 synchronize_users

--- a/hooks/post_user_delete
+++ b/hooks/post_user_delete
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+YNH_HELPERS_VERSION=2.1
+
 # IMPORT GENERIC HELPERS
 source /usr/share/yunohost/helpers
 

--- a/hooks/post_user_update
+++ b/hooks/post_user_update
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+YNH_HELPERS_VERSION=2.1
+
 ###
 # This hook is only used because yunohost doesn't trigger any hook when adding a user to a group (e.g. admin)
 # After adding a user to a group, one should update a user to trigger this hook (https://forum.yunohost.org/t/hook-when-a-user-is-added-in-a-group/25437)

--- a/hooks/post_user_update
+++ b/hooks/post_user_update
@@ -21,4 +21,5 @@ path=$(ynh_app_setting_get --app=$app --key=path)
 # Load common variables and helpers
 source ${pwd}/../../apps/${app}/scripts/_common.sh
 
+set_forgejo_login_source
 synchronize_users

--- a/hooks/post_user_update
+++ b/hooks/post_user_update
@@ -19,9 +19,18 @@ app=${filename#*-}
 
 domain=$(ynh_app_setting_get --app=$app --key=domain)
 path=$(ynh_app_setting_get --app=$app --key=path)
+install_dir="$(ynh_app_setting_get --app=$app --key=install_dir)"
+db_name="$(ynh_app_setting_get --app=$app --key=db_name)"
+group_sync_enabled="$(ynh_app_setting_get --app=$app --key=group_sync_enabled)"
+group_sync_included_organisations="$(ynh_app_setting_get --app=$app --key=group_sync_included_organisations)"
+group_sync_excluded_organisations="$(ynh_app_setting_get --app=$app --key=group_sync_excluded_organisations)"
+group_sync_included_ynh_group="$(ynh_app_setting_get --app=$app --key=group_sync_included_ynh_group)"
+group_sync_excluded_ynh_group="$(ynh_app_setting_get --app=$app --key=group_sync_excluded_ynh_group)"
 
 # Load common variables and helpers
 source ${pwd}/../../apps/${app}/scripts/_common.sh
 
+pushd ${pwd}/../../apps/${app}/scripts/
 set_forgejo_login_source
+popd
 synchronize_users

--- a/scripts/config
+++ b/scripts/config
@@ -6,6 +6,11 @@ source /usr/share/yunohost/helpers
 ynh_app_config_apply() {
     _ynh_app_config_apply
     ynh_config_add --template="app.ini" --destination="$install_dir/custom/conf/app.ini"
+    set_forgejo_login_source
+}
+
+run__sync_groups_mapping() {
+    set_forgejo_login_source
 }
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -74,10 +74,10 @@ ynh_systemctl --service="$app" --action="start" --log_path="/var/log/$app/forgej
 #=================================================
 # LDAP CONFIGURATION
 #=================================================
+
 ynh_script_progression "Adding LDAP configuration..."
 
 set_forgejo_login_source
-enable_login_source_sync
 
 # API user creation
 create_forgejo_api_user

--- a/scripts/login_source.sql
+++ b/scripts/login_source.sql
@@ -1,0 +1,43 @@
+UPDATE login_source
+SET
+    type=2,
+    is_active=true,
+    is_sync_enabled=true,
+    cfg='{
+        "Name": "YunoHost LDAP",
+        "Host": "localhost",
+        "Port": 389,
+        "SecurityProtocol": 0,
+        "SkipVerify": false,
+        "BindDN": "",
+        "BindPassword": "",
+        "UserBase": "ou=users,dc=yunohost,dc=org",
+        "UserDN": "",
+        "AttributeUsername": "uid",
+        "AttributeName": "givenName",
+        "AttributeSurname": "sn",
+        "AttributeMail": "mail",
+        "AttributesInBind": false,
+        "AttributeSSHPublicKey": "",
+        "AttributeAvatar": "",
+        "SearchPageSize": 0,
+        "Filter": "(&(uid=%s)(permission=cn={{ app }}.main,ou=permission,dc=yunohost,dc=org))",
+        "AdminFilter": "(permission=cn={{ app }}.admin,ou=permission,dc=yunohost,dc=org)",
+        "RestrictedFilter": "",
+        "Enabled": true,
+        "AllowDeactivateAll": false,
+        "GroupsEnabled": true,
+        "GroupDN": "ou=groups,dc=yunohost,dc=org",
+        "GroupFilter": "",
+        "GroupMemberUID": "memberUid",
+        "GroupTeamMap": "{% if group_sync_enabled == 'true' -%}{
+                {%- for e in list_group_mapping.splitlines() -%}
+                    {%- if loop.index > 1 -%}, {%- endif -%}
+                    \"cn={{ e.split('|')[1] }},ou=groups,dc=yunohost,dc=org\": {\"{{ e.split('|')[0] }}\": [\"{{ e.split('|')[1] }}\"]}
+                {%- endfor -%}}
+            {%- endif %}",
+        "GroupTeamMapRemoval": true,
+        "UserUID": "uid"
+    }',
+    updated_unix=(SELECT extract(epoch FROM NOW()))
+WHERE name='YunoHost LDAP';

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -17,27 +17,6 @@ ynh_systemctl --service="$app" --action="stop" --log_path="systemd"
 #=================================================
 ynh_script_progression "Ensuring downward compatibility..."
 
-# Update forgejo login source (1.19.3-0~ynh2)
-pushd "$install_dir"
-    old_login_source_id=$(ynh_exec_as_app ./forgejo admin auth list | grep "YunoHost LDAP" | grep "via BindDN" | cut -f 1)
-    if [ -n "$old_login_source_id" ]; then
-        ynh_print_info "Delete obsolete forgejo login source (LDAP via BindDN)"
-
-        # Ensure no user have this obsolete login source
-        ynh_psql_db_shell  "$db_name" --sql "update public.user set login_source = 0, login_type = 0 where login_source = ${old_login_source_id}"
-
-        # Delete old login source
-        ynh_exec_as_app ./forgejo admin auth delete --id "$old_login_source_id"
-    fi
-
-    ynh_exec_as_app ./forgejo admin auth list | grep "YunoHost LDAP" | grep -q "LDAP (simple auth)" ||
-        # create new login source if not existing
-        set_forgejo_login_source
-popd
-
-# Update login source synchronization flag (1.19.3-0~ynh3)
-enable_login_source_sync
-
 # forgejo home directory has changed (yunohost packaging v2)
 # .ssh directory should move from old home dir (data_dir) to new one
 # (/var/www/$app is the default value for home in resources.system_user)
@@ -109,7 +88,9 @@ if [ -z "${forgejo_api_user:-}" ]; then
     create_forgejo_api_user
 fi
 
-set_users_login_source
+ynh_print_info "Creating forgejo login source"
+
+set_forgejo_login_source
 
 synchronize_users
 


### PR DESCRIPTION
## Problem

- Currently there are no possibility to sync group

## Solution

- Configure group sync

## Clarification

The issue that we have is that on forgejo we can sync LDAP groups with a team of an organisation and the team need to be created independently on forgejo. And the mapping between the LDAP group and the forgejo team is mapped with the LDAP config.

So the idea was to generate the mapping, if the team name match the LDAP group. But we can think that we don't want to map all team of all organisation automatically. So the solution was to add from the config panel an option to enable/disable this feature. And to have more flexibility I also added some filter, so we can really decide which team need to be mapped with the Yunohost groups.

Note that to avoid conflict this branch is based on the config panel branch.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
