### PR TITLE
Improve docs/settings for group integration

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -137,3 +137,9 @@ ENABLED = __ACTIONS_ENABLED__
 
 [webhook]
 ALLOWED_HOST_LIST = __WEBHOOK_ALLOWED_HOSTS__
+
+[cron.sync_external_users]
+ENABLED = true
+RUN_AT_START = true
+SCHEDULE = @every 30m
+UPDATE_EXISTING = true

--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -1,12 +1,45 @@
 ## Additional informations
 
 ### User synchronization
+
 In order to allow access to Forgejo admin section, YunoHost users are automaticaly synchronized with Forgejo's.  
 You can use «Forgejo (admin)» permission to manage which user is considered as forgejo admin.
 
 The «forgejo (api)» permission must be set to «Visitors» group to allow user synchronization via an API call.
 
-**Known issue** : when a user is added to a group (e.g. the one with «Forgejo (admin)» permission), the synchronization is not triggered by YunoHost. You have to update a user (without any modification) to trigger it. (https://github.com/YunoHost/issues/issues/2213)
+Then, from the forgejo admin interface, click the « synchronize external user data » button to fetch new admins automatically without waiting for the automated daily sync.
+
+### Group synchronization
+
+**TLDR**:
+
+- when you add/remove a member from an existing group that's already synchronized, you need to press *Synchronize external user data* in Forgejo's admin interface, or wait 30 minutes for the changes to propagate
+- when you create/remove a Yunohost group or a Forgejo team, you need to press *Force sync group mapping* in Yunohost's Forgejo settings, then *Synchronize external user data* in Forgejo's admin interface
+
+It is possible to synchronize Yunohost groups directly to Forgejo « teams ». Teams are groups within each organization.
+
+Note that the synchronization only applies to existing Forgejo organizations, and only for existing teams which match a Yunohost group name. **Every time you create or remove an organization/team on Forgejo's side, or a group on Yunohost side, you need to press *Synchronize external user data* on Forgejo's admin interface.
+
+Let's take an example with two Forgejo organizations: **cooking** and **sports**.
+
+We would like:
+
+- Yunohost admins (**admins group**) to be members of the `admins` team in both organizations
+- Yunohost users members of the **cooks group**, to be part of the « cooks » team in the « cooking » organization on Forgejo
+- Yunohost users members of the **sports  group**
+  - to be part of the `sportive` team in the **sports organization** on Forgejo
+  - to be part fo the `sportive` team in the **cooking organization** on Forgejo
+
+For this purpose:
+
+- make sure `Enable group synchronisation from Yunohost to the organisation team members?` is `yes` and click `Save`
+- create **sportive group** and **cooks group** in Yunohost
+- create **sports organization** with `admins` and `sportive` teams
+- create **cooking organization** with `admins`, `cooks`, and `sportive` teams
+- click *Forge sync group mapping* in Yunohost's Forgejo settings
+- click *Synchronize external user data* on Forgejo's admin interface
+
+That's it! But please note that Yunohost group membership changes are not reflected instantly on Forgejo. You need to click *Synchronize external user data* in the Forgejo admin interface, or wait 30 minutes minutes for the changes to propagate.
 
 ### Notes on SSH usage
 


### PR DESCRIPTION
- document manual process for group sync
- set setting for automatic group sync every 5 minutes

Ideally, i'd like to automatically trigger the « force group sync mapping ». Maybe we could:

- store a copy of the group sync mapping in an "old" setting and update it when the action is run; this way we only tell forgejo to sync when there's an actual diff in existing groups
- compute the new value in the action every time permissions change or a user is added/removed to a group, or a group is created or (trickier) when a Forgejo team is created

I think for the moment this PR will already improve things.