### PR TITLE
feat: Support custom.ini custom config (solves #153)

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -1,4 +1,11 @@
-; WARNING: Don't edit this file. All change will be removed after each app upgrade
+; WARNING: Don't edit this file. All change will be removed
+; every time forgejo starts.
+;
+; You should only edit __INSTALL_DIR__/custom/conf/custom.ini where you can
+; override any value found in this file in a granular fashion, then restart
+; the forgejo service.
+;
+; You should see the changes appear in __INSTALL_DIR__/custom/conf/app.ini.
 ; 
 ; https://codeberg.org/forgejo/forgejo/src/branch/forgejo/custom/conf/app.example.ini
 APP_NAME = Forgejo

--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -7,6 +7,7 @@ Type=simple
 User=__APP__
 Group=__APP__
 WorkingDirectory=__INSTALL_DIR__/
+ExecStartPre=__INSTALL_DIR__/custom_config.py __INSTALL_DIR__/custom/conf/yunohost_default.ini __INSTALL_DIR__/custom/conf/custom.ini __INSTALL_DIR__/custom/conf/app.ini
 ExecStart=__INSTALL_DIR__/forgejo web -p __PORT__
 Restart=always
 Environment=USER=__APP__

--- a/doc/ADMIN.md
+++ b/doc/ADMIN.md
@@ -1,5 +1,12 @@
 ## Additional informations
 
+### Customize configuration
+
+Default Yunohost configuration is stored in `INSTALL_DIR/custom/conf/yunohost_default.ini`. Do not erase this file. Custom configuration
+can be added to `INSTALL_DIR/custom/conf/custom.ini`, overriding default configuration keys.
+
+The file `INSTALL_DIR/custom/conf/app.ini` contains the merged configuration values, and is regenerated every time forgejo starts.
+
 ### User synchronization
 In order to allow access to Forgejo admin section, YunoHost users are automaticaly synchronized with Forgejo's.  
 You can use «Forgejo (admin)» permission to manage which user is considered as forgejo admin.

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -146,6 +146,10 @@ ensure_vars_set() {
     ynh_app_setting_set_default --key=group_sync_included_ynh_group --value=''
 
     ynh_app_setting_set_default --key=federation_enabled --value='false'
+
+    if ! [ -f "$install_dir"/custom/conf/custom.ini ]; then
+        touch "$install_dir"/custom/conf/custom.ini
+    fi
 }
 
 set_permissions() {

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -23,10 +23,10 @@ ynh_config_change_url_nginx
 ynh_script_progression "Adding $app's configuration..."
 
 ssh_port=$(grep -P "Port\s+\d+" /etc/ssh/sshd_config | grep -P -o "\d+")
-ynh_hide_warnings ynh_config_add --template="app.ini" --destination="$install_dir/custom/conf/app.ini"
+ynh_config_add --template="app.ini" --destination="$install_dir/custom/conf/yunohost_default.ini"
 
-chmod 640 "$install_dir/custom/conf/app.ini"
-chown "$app:$app" "$install_dir/custom/conf/app.ini"
+chmod -R 640 "$install_dir/custom"
+chown -R "$app:$app" "$install_dir/custom"
 
 ynh_permission_url --permission=container_registry --url="$domain/v2"
 

--- a/scripts/config
+++ b/scripts/config
@@ -13,7 +13,7 @@ ynh_app_config_validate() {
 
 ynh_app_config_apply() {
     _ynh_app_config_apply
-    ynh_config_add --template="app.ini" --destination="$install_dir/custom/conf/app.ini"
+    ynh_config_add --template="app.ini" --destination="$install_dir/custom/conf/yunohost_default.ini"
     set_forgejo_login_source
 }
 

--- a/scripts/custom_config.py
+++ b/scripts/custom_config.py
@@ -1,0 +1,61 @@
+#! /usr/bin/env python3
+
+import configparser
+import io
+import os
+import sys
+
+custom_config = configparser.ConfigParser()
+config = configparser.ConfigParser()
+# Prevent turning keys to lowercase (should not happen on python 3.14)
+custom_config.optionxform = str
+config.optionxform = str
+# Will work in debian trixie (python 3.13+)
+# custom_config = configparser.ConfigParser(allow_unnamed_section=True)
+# with open(sys.argv[1]) as app:
+#     config.read_file(app)
+# Below is the workaround:
+with open(sys.argv[1]) as app:
+    currently_in_global_config = True
+    global_config_lines = []
+    specific_config_lines = []
+    for line in app.readlines():
+        if line.startswith("["):
+            currently_in_global_config = False
+
+        if currently_in_global_config:
+            global_config_lines.append(line)
+        else:
+            specific_config_lines.append(line)
+    config.read_string("".join(specific_config_lines))
+
+if os.path.isfile(sys.argv[2]):
+    with open(sys.argv[2]) as app_custom:
+        custom_config.read_file(app_custom)
+
+for section_name in custom_config.sections():
+    if not config.has_section(section_name):
+        config.add_section(section_name)
+
+    for key, value in custom_config.items(section_name, raw=True):
+        config.set(section_name, key, value)
+
+# with open(sys.argv[3], "w") as final:
+#     config.write(final)
+# Workaround:
+
+# print-based debugging
+#print("".join(global_config_lines))
+#for section in config.sections():
+#    print(f"[{section}]")
+#    for key, value in config.items(section, raw=True):
+#        print(key + " = " + value)
+
+#newConfigStr = io.StringIO("".join(global_config_lines))
+newConfigStr = io.StringIO()
+newConfigStr.write("".join(global_config_lines))
+config.write(newConfigStr)
+
+with open(sys.argv[3], "w") as final:
+    newConfigStr.seek(0)
+    final.write(newConfigStr.read())

--- a/scripts/install
+++ b/scripts/install
@@ -24,6 +24,8 @@ mkdir -p "$install_dir/custom/conf" "$install_dir/.ssh"
 chmod -R o-rwx "$install_dir/custom"
 chown -R "$app:$app" "$install_dir/custom"
 
+cp "custom_config.py" "$install_dir/custom_config.py"
+
 #=================================================
 # KEYS GENERATION
 #=================================================
@@ -44,10 +46,10 @@ ynh_script_progression "Adding $app's configuration files..."
 
 ensure_vars_set
 
-ynh_config_add --template="app.ini" --destination="$install_dir/custom/conf/app.ini"
+ynh_config_add --template="app.ini" --destination="$install_dir/custom/conf/yunohost_default.ini"
 
-chmod 640 "$install_dir/custom/conf/app.ini"
-chown "$app:$app" "$install_dir/custom/conf/app.ini"
+chmod -R 640 "$install_dir/custom"
+chown -R "$app:$app" "$install_dir/custom"
 
 #=================================================
 # SYSTEM CONFIGURATION

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -54,15 +54,17 @@ xz -f -d "$install_dir/forgejo.xz"
 
 chmod +x "$install_dir/forgejo"
 
+cp "custom_config.py" "$install_dir/custom_config.py"
+
 #=================================================
 # ADD A CONFIGURATION
 #=================================================
 ynh_script_progression "Adding $app's configuration..."
 
-ynh_config_add --template="app.ini" --destination="$install_dir/custom/conf/app.ini"
+ynh_config_add --template="app.ini" --destination="$install_dir/custom/conf/yunohost_default.ini"
 
-chmod 640 "$install_dir/custom/conf/app.ini"
-chown "$app:$app" "$install_dir/custom/conf/app.ini"
+chmod -R 640 "$install_dir/custom"
+chown -R "$app:$app" "$install_dir/custom"
 
 #=================================================
 # SETUP SYSTEMD


### PR DESCRIPTION
People were asking for custom config in #153. I had the same problem.

I realized we can just append new ini sections/keys at the end of file, and the later values will be used. However, this is not documented behavior in forgejo or in the upstream ini golang package, so i think it's safer to rely on a custom script that's started before the service.

I have not tested this PR because i don't have proper testing infra. But i tested the python script just fine, without custom.ini and with custom.ini with overriding values.

EDIT: sorry i opened against master branch again and now i cant change it